### PR TITLE
Mark NSNotification callback methods with @objc.

### DIFF
--- a/Classes/ESTMusicIndicatorView.swift
+++ b/Classes/ESTMusicIndicatorView.swift
@@ -126,7 +126,8 @@ public class ESTMusicIndicatorView: UIView {
         addSubview(contentView)
         prepareLayoutPriorities()
         setNeedsUpdateConstraints()
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationWillEnterForeground", name: UIApplicationWillEnterForegroundNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationDidEnterBackground:", name: UIApplicationDidEnterBackgroundNotification, object: nil)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationWillEnterForeground:", name: UIApplicationWillEnterForegroundNotification, object: nil)
     }
     
     private func prepareLayoutPriorities() {
@@ -204,13 +205,16 @@ public class ESTMusicIndicatorView: UIView {
     }
     
     // MARK: Notification
-    
-    private func applicationWillEnterForeground(notification: NSNotification) {
-        // When an app entered background, UIKit removes all animations
-        // even if it's an infinite animation.
-        // So we restart the animation here if it should be when the app came back to foreground.
-        if state == .ESTMusicIndicatorViewStatePlaying {
-            startAnimating()
-        }
-    }
+	
+	@objc
+	private func applicationDidEnterBackground(notification: NSNotification) {
+		stopAnimating()
+	}
+	
+	@objc
+	private func applicationWillEnterForeground(notification: NSNotification) {
+		if state == .ESTMusicIndicatorViewStatePlaying {
+			startAnimating()
+		}
+	}
 }


### PR DESCRIPTION
Currently the app crashes with 'unrecognized selector sent to instance' exception.
Mark applicationWillEnterForeground:  method with @objc so method is exposed to Objective-C.

Stop all animations explicitly in new applicationDidEnterBackground: method so it logically pairs with applicationWillEnterForeground: .
Also it works great if animations are not suspended by Apple for some reason/different iOS version.
